### PR TITLE
move site settings to data file, closes #23

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,11 +1,2 @@
-# Set a plain language title for the site.
-title: Plain Vanilla GitHub Pages
-
-# Write a short description for the site. This is used for "meta description."
-description: Free, easy, low-tech website template using GitHub Pages
-
-# Set the language for the site. Used for "html lang." Default is English.
-lang: en
-
 # Avoid GitHub API authentication when building locally.
 github: [metadata]

--- a/_data/metadata.yml
+++ b/_data/metadata.yml
@@ -1,0 +1,8 @@
+# Set the language for the site. Used for "html lang." Default is English.
+lang: en
+
+# Set a plain language title for the site.
+title: Plain Vanilla GitHub Pages
+
+# Write a short description for the site. This is used for "meta description."
+description: Free, easy, low-tech website template using GitHub Pages

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,10 +1,10 @@
 <!doctype html>
-<html lang="{{site.lang}}" data-color-mode="auto" data-light-theme="light" data-dark-theme="dark">
+<html lang="{{ site.data.metadata.lang | default: 'en' }}" data-color-mode="auto" data-light-theme="light" data-dark-theme="dark">
 
 <head>
   <meta charset="utf-8">
-  <title>{{ site.title }}</title>
-  <meta name="description" content="{{ site.description }}">
+  <title>{{ site.data.metadata.title | default: 'Plain Vanilla GitHub Pages' }}</title>
+  <meta name="description" content="{{ site.data.metadata.description | default: 'Free, easy, low-tech website template using GitHub Pages' }}">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <link rel="icon" href="favicon.ico" sizes="any">


### PR DESCRIPTION
- Created `_data/metadata.yml` for lang, title, and description content
- Added default values to layout (in case user-generated content not provided)
- Removed settings from `_config.yml`

The only thing in config now is `github: [metadata]`.